### PR TITLE
Added idnumber field

### DIFF
--- a/auth/onelogin_saml/auth.php
+++ b/auth/onelogin_saml/auth.php
@@ -50,6 +50,10 @@
 	set_config('field_lock_lastname', 'unlocked', 'auth/onelogin_saml');
 	set_config('field_updatelocal_lastname', 'oncreate', 'auth/onelogin_saml');
 	set_config('field_updatelocal_lastname', 'onlogin', 'auth/onelogin_saml');
+	
+	set_config('field_lock_idnumber', 'unlocked', 'auth/onelogin_saml');
+	set_config('field_updatelocal_idnumber', 'oncreate', 'auth/onelogin_saml');
+	set_config('field_updatelocal_idnumber', 'onlogin', 'auth/onelogin_saml');
 
 	set_config('field_updateremote_email', '0', 'auth/onelogin_saml');
 
@@ -127,11 +131,15 @@
 
 			$firstnameMapping = $mapping['firstname'];
 			$surnameMapping =  $mapping['lastname'];
+			$idnumberMapping = $mapping['idnumber'];
 			if (!empty($firstnameMapping) && isset($saml_attributes[$firstnameMapping]) && !empty($saml_attributes[$firstnameMapping][0])){
 				$user['firstname'] = $saml_attributes[$firstnameMapping][0];
 			}
 			if (!empty($surnameMapping) && isset($saml_attributes[$surnameMapping]) && !empty($saml_attributes[$surnameMapping][0])){
 				$user['lastname'] = $saml_attributes[$surnameMapping][0];
+			}
+			if (!empty($idnumberMapping) && isset($saml_attributes[$idnumberMapping]) && !empty($saml_attributes[$idnumberMapping][0])){
+				$user['idnumber'] = $saml_attributes[$idnumberMapping][0];
 			}
 
 			$saml_account_matcher = $this->config->saml_account_matcher;
@@ -157,6 +165,7 @@
 				"email" => $this->config->saml_email_map,
 				"firstname" => $this->config->saml_firstname_map,
 				"lastname" => $this->config->saml_surname_map,
+				"idnumber" => $this->config->saml_idnumber_map,
 			);
 
 			return $moodleattributes;
@@ -364,6 +373,9 @@
 			if (!isset($config->saml_surname_map)) {
 				$config->saml_surname_map = '';
 			}
+			if (!isset($config->saml_idnumber_map)) {
+				$config->saml_idnumber_map = '';
+			}
 			if (!isset($config->saml_role_map)) {
 				$config->saml_role_map = '';
 			}
@@ -432,6 +444,7 @@
 			set_config('saml_email_map',  trim($config->saml_email_map), 'auth/onelogin_saml');
 			set_config('saml_firstname_map',  trim($config->saml_firstname_map), 'auth/onelogin_saml');
 			set_config('saml_surname_map',  trim($config->saml_surname_map), 'auth/onelogin_saml');
+			set_config('saml_idnumber_map',  trim($config->saml_idnumber_map), 'auth/onelogin_saml');
 			set_config('saml_role_map',  trim($config->saml_role_map), 'auth/onelogin_saml');
 			set_config('saml_role_siteadmin_map',  trim($config->saml_role_siteadmin_map), 'auth/onelogin_saml');
 			set_config('saml_role_coursecreator_map',  trim($config->saml_role_coursecreator_map), 'auth/onelogin_saml');
@@ -521,6 +534,7 @@
 				'saml_email_map' => get_string("auth_onelogin_saml_email_map", "auth_onelogin_saml"),
 				'saml_firstname_map' => get_string("auth_onelogin_saml_firstname_map", "auth_onelogin_saml"),
 				'saml_surname_map' => get_string("auth_onelogin_saml_surname_map", "auth_onelogin_saml"),
+				'saml_idnumber_map' => get_string("auth_onelogin_saml_idnumber_map", "auth_onelogin_saml"),
 				'saml_role_map' => get_string("auth_onelogin_saml_role_map", "auth_onelogin_saml"),
 			);
 

--- a/auth/onelogin_saml/config.html
+++ b/auth/onelogin_saml/config.html
@@ -71,6 +71,9 @@
     if (!isset($config->saml_surname_map)) {
         $config->saml_surname_map = '';
     }
+    if (!isset($config->saml_idnumber_map)) {
+        $config->saml_idnumber_map = '';
+    }
     if (!isset($config->saml_role_map)) {
         $config->saml_role_map = '';
     }
@@ -278,6 +281,12 @@ if (isset($err['saml_surname_map_empty'])) {
     <td align="right" style="font-size:12px; font-weight:bold;min-width: 180px;"><?php print_string("auth_onelogin_saml_surname_map", "auth_onelogin_saml"); ?>:</td>
     <td>
         <input name="saml_surname_map" type="text" value="<?php if ($config->saml_surname_map) echo $config->saml_surname_map; ?>" style="color:blue; width:150px; " />
+    </td>
+</tr>
+<tr valign="top">
+    <td align="right" style="font-size:12px; font-weight:bold;min-width: 180px;"><?php print_string("auth_onelogin_saml_idnumber_map", "auth_onelogin_saml"); ?>:</td>
+    <td>
+        <input name="saml_idnumber_map" type="text" value="<?php if ($config->saml_idnumber_map) echo $config->saml_idnumber_map; ?>" style="color:blue; width:150px; " />
     </td>
 </tr>
 <tr valign="top">

--- a/auth/onelogin_saml/functions.php
+++ b/auth/onelogin_saml/functions.php
@@ -193,6 +193,11 @@
 						$DB->set_field('user', 'lastname', $user_saml['lastname'], $query_conditions);
 						$user->lastname = $user_saml['lastname'];
 					}
+					if (!empty($user_saml['idnumber']) && $user->idnumber != $user_saml['idnumber']) {
+						$query_conditions['id'] = $user->id;
+						$DB->set_field('user', 'idnumber', $user_saml['idnumber'], $query_conditions);
+						$user->idnumber = $user_saml['idnumber'];
+					}
 
 					$authplugin->sync_roles($user);
 				}

--- a/auth/onelogin_saml/lang/en/auth_onelogin_saml.php
+++ b/auth/onelogin_saml/lang/en/auth_onelogin_saml.php
@@ -97,6 +97,7 @@
 	$string['auth_onelogin_saml_email_map'] = "Email Address";
 	$string['auth_onelogin_saml_firstname_map'] = "First Name";
 	$string['auth_onelogin_saml_surname_map'] = "Surname";
+	$string['auth_onelogin_saml_idnumber_map'] = "IDnumber";
 	$string['auth_onelogin_saml_role_map'] = "Role";	
 
 	$string['auth_onelogin_saml_rolemapping_head'] = "The IdP can use it's own roles. Set in this section the mapping between IdP and Moodle roles. Accepts multiple valued comma separated. Example: admin,owner,superuser.";


### PR DESCRIPTION
Allows to update mdl_user idnumber field via data from OneLogin if the
mapping is set up. IDnumber mapping field is optional and won’t update
if it is left blank.